### PR TITLE
Add macOS ScreenCaptureKit recorder with AVFoundation fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,24 @@ go run ./cmd/tester run --plan-only
 go run ./cmd/tester run
 ```
 
+### macOS native build & signing requirements
+
+- CGO is required for the recorder; ensure `CGO_ENABLED=1` and build on macOS with Xcode 14.3+ (Command Line Tools installed) so ScreenCaptureKit and AVFoundation frameworks are available.
+- The binary must be codesigned with the Hardened Runtime enabled and the following entitlements:
+  - `com.apple.security.screen-recording` – grants ScreenCaptureKit access on macOS 12.3+.
+  - `com.apple.security.device.audio-input` – required by ScreenCaptureKit/AVFoundation when audio routing is enabled.
+  - Optional: `com.apple.security.get-task-allow` should remain `false` for release builds.
+- Create an entitlement file (e.g. `entitlements.plist`) and sign the compiled binary:
+
+  ```bash
+  /usr/libexec/PlistBuddy -c "Add :com.apple.security.screen-recording bool true" entitlements.plist
+  /usr/libexec/PlistBuddy -c "Add :com.apple.security.device.audio-input bool true" entitlements.plist
+  codesign --force --options runtime --entitlements entitlements.plist \
+    --sign "Developer ID Application: YOUR TEAM" ./tester
+  ```
+
+- Grant the executable Screen Recording permission after the first launch via **System Settings → Privacy & Security → Screen Recording**. Permissions must be re-authorised if the binary signature changes.
+
 ### Configuration & Logging
 
 - The CLI reads `config.yaml` from the working directory when present. Flags such as `--config`, `--log-level`, and `--log-format` override file values.
@@ -36,7 +54,7 @@ Each CLI subcommand currently reports roadmap status while capture features evol
 
 - **Event tap** – Generates deterministic keyboard, mouse, window, and clipboard samples at fine/coarse intervals, applies email/custom regex redaction, and writes both JSONL and bucketed summaries under `events/`.
 - **Screenshot scheduler** – Produces throttled placeholder screenshots (timestamped text markers) based on configurable intervals and per-minute limits under `screenshots/`.
-- **Video recorder** – Emits a synthetic segment file in the configured format/rotation, recording capture window metadata for future playback coordination under `video/`.
+- **Video recorder** – Streams the primary display to H.264 MP4 segments under `video/`, preferring ScreenCaptureKit on macOS 12.3+ and falling back to AVFoundation capture on older releases while preserving `chunk_seconds` boundaries.
 - **ASR agent** – Detects meeting window titles, checks Whisper availability, writes VTT transcripts when available, and records guidance/status JSON under `asr/` when the binary is missing.
 - **OCR worker** – Reads captured screenshots, applies privacy redaction, emits `index.json` summaries plus status metadata under `ocr/` while tolerating missing Tesseract installations.
 - **Privacy controls** – Allow-list enforcement trims events to approved apps/URLs and reports filtered counts for downstream auditing.

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -62,7 +62,7 @@
 
 - **Event tap**: current Go implementation synthesises keyboard, mouse, window-focus, and clipboard events at configurable fine/coarse intervals. A redaction pipeline masks emails and custom regex patterns before persisting JSONL streams and bucket summaries under `events/`. These fixtures unblock downstream processing and privacy validation while native integrations are scoped.
 - **Screenshot scheduler**: deterministic scheduler throttles captures according to interval/limit configuration. Placeholder text artifacts stand in for PNGs and are timestamped for future OCR alignment.
-- **Video recorder**: lightweight recorder stub emits a single segment file per run with capture start/end metadata. It enables bundle/report flows to reason about video layout without requiring AVFoundation bindings yet.
+- **Video recorder**: native macOS implementation captures the primary display into H.264 MP4 segments. ScreenCaptureKit (`SCShareableContent`/`SCStream`) powers macOS 12.3+ hosts while AVFoundation (`AVCaptureScreenInput`) provides a fallback on older systems so downstream tooling always receives real video assets.
 
 The long-term design still targets macOS native APIs (AVFoundation, CGEventTap, CGWindowListCreateImage). The stubs mirror their data contracts so that replacing them with production integrations only affects subsystem internals.
 

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -100,7 +100,8 @@ summarizer:
 
 ## Implementation Decisions
 - Language: Go with minimal vendored dependencies.
-- Screen recording: use vendored `github.com/blacktop/go-macscreenrec` for AVFoundation capture.
+- Screen recording: CGO bindings to ScreenCaptureKit on macOS 12.3+ with an AVFoundation (`AVCaptureScreenInput`/`AVAssetWriter`) fallback for older hosts; produces MP4 segments bounded by `chunk_seconds`.
+- Signing: Hardened Runtime codesign with `com.apple.security.screen-recording` and `com.apple.security.device.audio-input` entitlements so ScreenCaptureKit/AVFoundation APIs function outside of Xcode.
 - OCR: auto-detect local Tesseract binary; disable gracefully with user guidance when absent.
 - ASR: auto-detect local Whisper.cpp binary; enable only for meeting windows and note when unavailable.
 - Tokenizer: embed offline BPE tokenizer with bundled vocab.

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -106,10 +106,10 @@ func Default() Config {
 			EventsEnabled:      true,
 			ASREnabled:         true,
 			OCREnabled:         true,
-			Video: VideoConfig{
-				ChunkSeconds: 300,
-				Format:       "webm",
-			},
+                        Video: VideoConfig{
+                                ChunkSeconds: 300,
+                                Format:       "mp4",
+                        },
 			Screenshots: ScreenshotConfig{
 				IntervalSeconds: 60,
 				MaxPerMinute:    3,

--- a/pkg/video/recorder_darwin.go
+++ b/pkg/video/recorder_darwin.go
@@ -1,0 +1,93 @@
+//go:build darwin
+
+package video
+
+/*
+#cgo CFLAGS: -x objective-c -fobjc-arc -fmodules
+#cgo LDFLAGS: -framework Foundation -framework AVFoundation -framework ScreenCaptureKit -framework CoreMedia -framework CoreVideo -framework VideoToolbox
+#include "recorder_darwin.h"
+*/
+import "C"
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"path/filepath"
+	"sync"
+	"time"
+	"unsafe"
+)
+
+type macRecorder struct {
+	format string
+	mu     sync.Mutex
+}
+
+func newNativeRecorder(format string) (NativeRecorder, error) {
+	if format != "mp4" {
+		return nil, fmt.Errorf("format %q is not supported on macOS recorder", format)
+	}
+	if C.recorder_initialize() != 0 {
+		return nil, errors.New("screen recording frameworks are not available")
+	}
+	return &macRecorder{format: format}, nil
+}
+
+func (m *macRecorder) Record(ctx context.Context, dest string, filename string, started time.Time, duration time.Duration) (string, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	absDir, err := filepath.Abs(dest)
+	if err != nil {
+		return "", fmt.Errorf("resolve destination: %w", err)
+	}
+	absFile := filepath.Join(absDir, filename)
+
+	durationSeconds := duration.Seconds()
+	if durationSeconds <= 0 {
+		return "", errors.New("duration must be positive")
+	}
+
+	cPath := C.CString(absFile)
+	defer C.free(unsafe.Pointer(cPath))
+
+	errCh := make(chan error, 1)
+	go func() {
+		var cerr *C.char
+		rc := C.recorder_record_screen(cPath, C.double(durationSeconds), &cerr)
+		if cerr != nil {
+			errMsg := C.GoString(cerr)
+			C.recorder_free_string(cerr)
+			errCh <- errors.New(errMsg)
+			return
+		}
+		if rc != 0 {
+			errCh <- fmt.Errorf("recording failed with status %d", int(rc))
+			return
+		}
+		errCh <- nil
+	}()
+
+	if ctx != nil {
+		select {
+		case <-ctx.Done():
+			C.recorder_cancel_active()
+			err := <-errCh
+			if err != nil {
+				return "", err
+			}
+			return "", ctx.Err()
+		case err := <-errCh:
+			if err != nil {
+				return "", err
+			}
+		}
+	} else {
+		if err := <-errCh; err != nil {
+			return "", err
+		}
+	}
+
+	return absFile, nil
+}

--- a/pkg/video/recorder_darwin.h
+++ b/pkg/video/recorder_darwin.h
@@ -1,0 +1,9 @@
+#ifndef LIMITLESS_CONTEXT_RECORDER_DARWIN_H
+#define LIMITLESS_CONTEXT_RECORDER_DARWIN_H
+
+int recorder_initialize(void);
+int recorder_record_screen(const char *path, double duration, char **error_out);
+void recorder_cancel_active(void);
+void recorder_free_string(char *ptr);
+
+#endif

--- a/pkg/video/recorder_darwin.mm
+++ b/pkg/video/recorder_darwin.mm
@@ -1,0 +1,459 @@
+//go:build darwin
+
+#import <Foundation/Foundation.h>
+#import <AVFoundation/AVFoundation.h>
+#import <ScreenCaptureKit/ScreenCaptureKit.h>
+#import <CoreGraphics/CoreGraphics.h>
+#import <CoreMedia/CoreMedia.h>
+#import <CoreVideo/CoreVideo.h>
+#import <string.h>
+#import <stdlib.h>
+#import "recorder_darwin.h"
+
+@interface RecorderSampleWriter : NSObject <SCStreamOutput, AVCaptureVideoDataOutputSampleBufferDelegate>
+@property(nonatomic, strong) AVAssetWriter *writer;
+@property(nonatomic, strong) AVAssetWriterInput *videoInput;
+@property(nonatomic) CMTime startTime;
+@property(nonatomic) BOOL started;
+@property(nonatomic) NSTimeInterval duration;
+@property(nonatomic) dispatch_semaphore_t finishSemaphore;
+@property(nonatomic) BOOL finished;
+@property(nonatomic) BOOL cancelled;
+@property(nonatomic, strong) NSError *error;
+@property(nonatomic, copy) void (^stopHandler)(void);
+@end
+
+@implementation RecorderSampleWriter
+
+- (instancetype)initWithURL:(NSURL *)url
+                   duration:(NSTimeInterval)duration
+                        size:(CGSize)size
+                       error:(NSError **)error {
+    self = [super init];
+    if (!self) {
+        return nil;
+    }
+
+    _duration = duration;
+    _finishSemaphore = dispatch_semaphore_create(0);
+
+    [[NSFileManager defaultManager] removeItemAtURL:url error:nil];
+
+    NSDictionary *compression = @{AVVideoProfileLevelKey: AVVideoProfileLevelH264HighAutoLevel,
+                                  AVVideoAverageBitRateKey: @(12 * 1000 * 1000)};
+    NSDictionary *settings = @{AVVideoCodecKey: AVVideoCodecTypeH264,
+                               AVVideoWidthKey: @(MAX(1.0, size.width)),
+                               AVVideoHeightKey: @(MAX(1.0, size.height)),
+                               AVVideoCompressionPropertiesKey: compression};
+
+    _writer = [AVAssetWriter assetWriterWithURL:url fileType:AVFileTypeMPEG4 error:error];
+    if (!_writer) {
+        return nil;
+    }
+
+    _videoInput = [AVAssetWriterInput assetWriterInputWithMediaType:AVMediaTypeVideo outputSettings:settings];
+    _videoInput.expectsMediaDataInRealTime = YES;
+
+    if ([_writer canAddInput:_videoInput]) {
+        [_writer addInput:_videoInput];
+    } else {
+        if (error) {
+            *error = [NSError errorWithDomain:AVFoundationErrorDomain
+                                         code:-1
+                                     userInfo:@{NSLocalizedDescriptionKey : @"Unable to add video input"}];
+        }
+        return nil;
+    }
+
+    return self;
+}
+
+- (void)finishWithError:(NSError *)error {
+    if (self.finished) {
+        return;
+    }
+    self.finished = YES;
+    if (error && !self.error) {
+        self.error = error;
+    }
+    if (!self.started) {
+        [self.writer cancelWriting];
+        dispatch_semaphore_signal(self.finishSemaphore);
+        if (self.stopHandler) {
+            self.stopHandler();
+        }
+        return;
+    }
+
+    [self.videoInput markAsFinished];
+    __block dispatch_semaphore_t semaphore = self.finishSemaphore;
+    [self.writer finishWritingWithCompletionHandler:^{
+        dispatch_semaphore_signal(semaphore);
+    }];
+    if (self.stopHandler) {
+        self.stopHandler();
+    }
+}
+
+- (void)processSampleBuffer:(CMSampleBufferRef)sampleBuffer {
+    if (self.finished || self.cancelled) {
+        return;
+    }
+
+    if (!CMSampleBufferDataIsReady(sampleBuffer)) {
+        return;
+    }
+
+    CMTime presentation = CMSampleBufferGetPresentationTimeStamp(sampleBuffer);
+    if (!self.started) {
+        self.started = YES;
+        self.startTime = presentation;
+        if (![self.writer startWriting]) {
+            NSError *error = self.writer.error ?: [NSError errorWithDomain:AVFoundationErrorDomain
+                                                                      code:-2
+                                                                  userInfo:@{NSLocalizedDescriptionKey : @"Failed to start AVAssetWriter"}];
+            [self finishWithError:error];
+            return;
+        }
+        [self.writer startSessionAtSourceTime:presentation];
+    }
+
+    CMTime relative = CMSampleBufferGetPresentationTimeStamp(sampleBuffer);
+    double elapsed = CMTimeGetSeconds(CMTimeSubtract(relative, self.startTime));
+    if (elapsed >= self.duration) {
+        [self finishWithError:nil];
+        return;
+    }
+
+    if (self.videoInput.readyForMoreMediaData) {
+        if (![self.videoInput appendSampleBuffer:sampleBuffer]) {
+            NSError *error = self.writer.error ?: [NSError errorWithDomain:AVFoundationErrorDomain
+                                                                      code:-3
+                                                                  userInfo:@{NSLocalizedDescriptionKey : @"Failed to append sample buffer"}];
+            [self finishWithError:error];
+        }
+    }
+}
+
+- (void)stream:(SCStream *)stream didOutputSampleBuffer:(CMSampleBufferRef)sampleBuffer ofType:(SCStreamOutputType)type API_AVAILABLE(macos(12.3)) {
+    if (type != SCStreamOutputTypeScreen) {
+        return;
+    }
+    [self processSampleBuffer:sampleBuffer];
+}
+
+- (void)captureOutput:(AVCaptureOutput *)output didOutputSampleBuffer:(CMSampleBufferRef)sampleBuffer fromConnection:(AVCaptureConnection *)connection {
+    [self processSampleBuffer:sampleBuffer];
+}
+
+- (void)cancelWithError:(NSError *)error {
+    if (self.cancelled) {
+        return;
+    }
+    self.cancelled = YES;
+    [self finishWithError:error];
+}
+
+@end
+
+@interface RecorderController : NSObject
+@property(nonatomic, strong) RecorderSampleWriter *writer;
+@property(nonatomic, strong) SCStream *stream API_AVAILABLE(macos(12.3));
+@property(nonatomic) dispatch_queue_t streamQueue;
+@property(nonatomic, strong) AVCaptureSession *session;
+@property(nonatomic, strong) AVCaptureVideoDataOutput *videoOutput;
+@property(nonatomic) dispatch_semaphore_t stopSemaphore;
+@end
+
+@implementation RecorderController
+
+- (BOOL)recordToURL:(NSURL *)url duration:(NSTimeInterval)duration error:(NSError **)error {
+    if (@available(macOS 12.3, *)) {
+        return [self recordWithScreenCaptureKitToURL:url duration:duration error:error];
+    }
+    return [self recordWithAVFoundationToURL:url duration:duration error:error];
+}
+
+- (BOOL)recordWithScreenCaptureKitToURL:(NSURL *)url duration:(NSTimeInterval)duration error:(NSError **)error API_AVAILABLE(macos(12.3)) {
+    __block SCShareableContent *content = nil;
+    __block NSError *contentError = nil;
+    dispatch_semaphore_t sema = dispatch_semaphore_create(0);
+    [SCShareableContent currentShareableContentWithCompletionHandler:^(SCShareableContent * _Nullable shareableContent, NSError * _Nullable err) {
+        content = shareableContent;
+        contentError = err;
+        dispatch_semaphore_signal(sema);
+    }];
+    dispatch_semaphore_wait(sema, DISPATCH_TIME_FOREVER);
+    if (!content) {
+        if (error) {
+            *error = contentError ?: [NSError errorWithDomain:SCStreamErrorDomain code:-1 userInfo:@{NSLocalizedDescriptionKey : @"Unable to enumerate displays"}];
+        }
+        return NO;
+    }
+
+    SCDisplay *display = content.displays.firstObject;
+    for (SCDisplay *candidate in content.displays) {
+        if (candidate.isMainDisplay) {
+            display = candidate;
+            break;
+        }
+    }
+
+    if (!display) {
+        if (error) {
+            *error = [NSError errorWithDomain:SCStreamErrorDomain code:-2 userInfo:@{NSLocalizedDescriptionKey : @"No displays available"}];
+        }
+        return NO;
+    }
+
+    CGSize size = CGSizeMake(display.width, display.height);
+    NSError *writerError = nil;
+    self.writer = [[RecorderSampleWriter alloc] initWithURL:url duration:duration size:size error:&writerError];
+    if (!self.writer) {
+        if (error) {
+            *error = writerError;
+        }
+        return NO;
+    }
+
+    self.streamQueue = dispatch_queue_create("com.limitless-context.recorder.stream", DISPATCH_QUEUE_SERIAL);
+    self.stopSemaphore = dispatch_semaphore_create(0);
+
+    __weak typeof(self) weakSelf = self;
+    self.writer.stopHandler = ^{
+        __strong typeof(self) strongSelf = weakSelf;
+        if (!strongSelf) {
+            return;
+        }
+        [strongSelf stopStream];
+    };
+
+    SCStreamConfiguration *configuration = [[SCStreamConfiguration alloc] init];
+    configuration.width = size.width;
+    configuration.height = size.height;
+    configuration.minimumFrameInterval = CMTimeMake(1, 60);
+    configuration.queueDepth = 8;
+    configuration.showsCursor = YES;
+    configuration.colorSpaceName = kCGColorSpaceSRGB;
+    configuration.pixelFormat = kCVPixelFormatType_420YpCbCr8BiPlanarVideoRange;
+
+    self.stream = [[SCStream alloc] initWithFilter:display configuration:configuration delegate:nil];
+
+    NSError *outputError = nil;
+    if (![self.stream addStreamOutput:self.writer type:SCStreamOutputTypeScreen sampleHandlerQueue:self.streamQueue error:&outputError]) {
+        if (error) {
+            *error = outputError ?: [NSError errorWithDomain:SCStreamErrorDomain code:-3 userInfo:@{NSLocalizedDescriptionKey : @"Failed to add stream output"}];
+        }
+        return NO;
+    }
+
+    dispatch_semaphore_t startSemaphore = dispatch_semaphore_create(0);
+    __block NSError *startError = nil;
+    [self.stream startCaptureWithCompletionHandler:^(NSError * _Nullable err) {
+        startError = err;
+        dispatch_semaphore_signal(startSemaphore);
+    }];
+    dispatch_semaphore_wait(startSemaphore, DISPATCH_TIME_FOREVER);
+    if (startError) {
+        if (error) {
+            *error = startError;
+        }
+        return NO;
+    }
+
+    dispatch_semaphore_wait(self.writer.finishSemaphore, DISPATCH_TIME_FOREVER);
+    dispatch_semaphore_wait(self.stopSemaphore, DISPATCH_TIME_FOREVER);
+
+    if (self.writer.error && error) {
+        *error = self.writer.error;
+    }
+
+    return self.writer.error == nil;
+}
+
+- (void)stopStream API_AVAILABLE(macos(12.3)) {
+    if (!self.stream) {
+        dispatch_semaphore_signal(self.stopSemaphore);
+        return;
+    }
+    __block NSError *stopError = nil;
+    dispatch_semaphore_t stopSemaphore = dispatch_semaphore_create(0);
+    [self.stream stopCaptureWithCompletionHandler:^(NSError * _Nullable err) {
+        stopError = err;
+        dispatch_semaphore_signal(stopSemaphore);
+    }];
+    dispatch_semaphore_wait(stopSemaphore, DISPATCH_TIME_FOREVER);
+    if (stopError && !self.writer.error) {
+        self.writer.error = stopError;
+    }
+    dispatch_semaphore_signal(self.stopSemaphore);
+}
+
+- (BOOL)recordWithAVFoundationToURL:(NSURL *)url duration:(NSTimeInterval)duration error:(NSError **)error {
+    CGDirectDisplayID displayID = CGMainDisplayID();
+    CGSize size = CGSizeMake(CGDisplayPixelsWide(displayID), CGDisplayPixelsHigh(displayID));
+
+    NSError *writerError = nil;
+    self.writer = [[RecorderSampleWriter alloc] initWithURL:url duration:duration size:size error:&writerError];
+    if (!self.writer) {
+        if (error) {
+            *error = writerError;
+        }
+        return NO;
+    }
+
+    self.stopSemaphore = dispatch_semaphore_create(0);
+
+    __weak typeof(self) weakSelf = self;
+    self.writer.stopHandler = ^{
+        __strong typeof(self) strongSelf = weakSelf;
+        if (!strongSelf) {
+            return;
+        }
+        [strongSelf stopSession];
+    };
+
+    self.session = [[AVCaptureSession alloc] init];
+    self.session.sessionPreset = AVCaptureSessionPresetHigh;
+
+    AVCaptureScreenInput *screenInput = [[AVCaptureScreenInput alloc] initWithDisplayID:displayID];
+    screenInput.minFrameDuration = CMTimeMake(1, 60);
+    screenInput.capturesCursor = YES;
+    screenInput.capturesMouseClicks = YES;
+
+    if ([self.session canAddInput:screenInput]) {
+        [self.session addInput:screenInput];
+    } else {
+        if (error) {
+            *error = [NSError errorWithDomain:AVFoundationErrorDomain code:-10 userInfo:@{NSLocalizedDescriptionKey : @"Unable to add screen input"}];
+        }
+        return NO;
+    }
+
+    self.videoOutput = [[AVCaptureVideoDataOutput alloc] init];
+    self.videoOutput.alwaysDiscardsLateVideoFrames = NO;
+    NSDictionary *videoSettings = @{(NSString *)kCVPixelBufferPixelFormatTypeKey : @(kCVPixelFormatType_420YpCbCr8BiPlanarVideoRange)};
+    self.videoOutput.videoSettings = videoSettings;
+
+    dispatch_queue_t queue = dispatch_queue_create("com.limitless-context.recorder.capture", DISPATCH_QUEUE_SERIAL);
+    [self.videoOutput setSampleBufferDelegate:self.writer queue:queue];
+
+    if ([self.session canAddOutput:self.videoOutput]) {
+        [self.session addOutput:self.videoOutput];
+    } else {
+        if (error) {
+            *error = [NSError errorWithDomain:AVFoundationErrorDomain code:-11 userInfo:@{NSLocalizedDescriptionKey : @"Unable to add video output"}];
+        }
+        return NO;
+    }
+
+    [self.session startRunning];
+
+    dispatch_semaphore_wait(self.writer.finishSemaphore, DISPATCH_TIME_FOREVER);
+    dispatch_semaphore_wait(self.stopSemaphore, DISPATCH_TIME_FOREVER);
+
+    if (self.writer.error && error) {
+        *error = self.writer.error;
+    }
+
+    return self.writer.error == nil;
+}
+
+- (void)stopSession {
+    if (!self.session) {
+        dispatch_semaphore_signal(self.stopSemaphore);
+        return;
+    }
+    [self.session stopRunning];
+    dispatch_semaphore_signal(self.stopSemaphore);
+}
+
+- (void)cancel {
+    NSError *cancelError = [NSError errorWithDomain:NSCocoaErrorDomain code:NSUserCancelledError userInfo:nil];
+    [self.writer cancelWithError:cancelError];
+}
+
+@end
+
+static RecorderController *gActiveController;
+static dispatch_queue_t gStateQueue;
+
+static char *recorder_copy_cstring(NSString *string) {
+    if (!string) {
+        return NULL;
+    }
+    const char *utf8 = [string UTF8String];
+    if (!utf8) {
+        return NULL;
+    }
+    size_t length = strlen(utf8) + 1;
+    char *buffer = malloc(length);
+    if (!buffer) {
+        return NULL;
+    }
+    memcpy(buffer, utf8, length);
+    return buffer;
+}
+
+int recorder_initialize(void) {
+    @autoreleasepool {
+        if (!gStateQueue) {
+            gStateQueue = dispatch_queue_create("com.limitless-context.recorder.state", DISPATCH_QUEUE_SERIAL);
+        }
+        return 0;
+    }
+}
+
+int recorder_record_screen(const char *path, double duration, char **error_out) {
+    @autoreleasepool {
+        if (!gStateQueue) {
+            gStateQueue = dispatch_queue_create("com.limitless-context.recorder.state", DISPATCH_QUEUE_SERIAL);
+        }
+        if (!path) {
+            if (error_out) {
+                *error_out = recorder_copy_cstring(@"destination path is required");
+            }
+            return -1;
+        }
+        NSString *filePath = [NSString stringWithUTF8String:path];
+        NSURL *url = [NSURL fileURLWithPath:filePath];
+        RecorderController *controller = [[RecorderController alloc] init];
+        __block RecorderController *previous = nil;
+        dispatch_sync(gStateQueue, ^{
+            previous = gActiveController;
+            gActiveController = controller;
+        });
+        if (previous) {
+            [previous cancel];
+        }
+
+        NSError *error = nil;
+        BOOL success = [controller recordToURL:url duration:duration error:&error];
+
+        dispatch_sync(gStateQueue, ^{
+            gActiveController = nil;
+        });
+
+        if (!success) {
+            if (error_out && error) {
+                *error_out = recorder_copy_cstring(error.localizedDescription ?: @"recording failed");
+            }
+            return -1;
+        }
+        return 0;
+    }
+}
+
+void recorder_cancel_active(void) {
+    @autoreleasepool {
+        dispatch_sync(gStateQueue, ^{
+            [gActiveController cancel];
+        });
+    }
+}
+
+void recorder_free_string(char *ptr) {
+    if (ptr) {
+        free(ptr);
+    }
+}

--- a/pkg/video/recorder_stub.go
+++ b/pkg/video/recorder_stub.go
@@ -1,0 +1,28 @@
+//go:build !darwin
+
+package video
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+)
+
+type stubRecorder struct {
+	format string
+}
+
+func newNativeRecorder(format string) (NativeRecorder, error) {
+	if format != "mp4" {
+		return nil, fmt.Errorf("format %q is unsupported on this platform", format)
+	}
+	return &stubRecorder{format: format}, nil
+}
+
+func (s *stubRecorder) Record(ctx context.Context, dest string, filename string, started time.Time, duration time.Duration) (string, error) {
+	if ctx != nil && ctx.Err() != nil {
+		return "", ctx.Err()
+	}
+	return "", errors.New("screen recording is only supported on macOS")
+}


### PR DESCRIPTION
## Summary
- replace the video recorder stub with a native interface and macOS implementation that streams H.264 MP4 segments via ScreenCaptureKit or an AVFoundation fallback
- update configuration defaults, documentation, and test fakes to reflect MP4-only output and preserve CI coverage on non-macOS hosts
- document the signing entitlements and toolchain requirements needed to build and run the native recorder

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68e32180b8d88328b5819bfa3f666547